### PR TITLE
Fixing missing default value for brightness

### DIFF
--- a/files/usr/local/lib/python2.7/site-packages/nclock/LedController.py
+++ b/files/usr/local/lib/python2.7/site-packages/nclock/LedController.py
@@ -39,6 +39,7 @@ class LedController(object):
     """ Constructor """
     self._settings = settings
     self._lock     = threading.Lock()
+    self._brightness = 0
 
     # set time and brightness
     self._initialize()


### PR DESCRIPTION
This fixes a bug when reaching line 93 in _set_brightness(): `self._settings.log.msg("LedController: setting brightness to: %d" % self._brightness)` before self._brightness was ever assigned.